### PR TITLE
Fakelogin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,11 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build:
-        branches:
-          ignore:
-            - staging
-            - fakelogin
+        filters:
+          branches:
+            ignore:
+              - staging
+              - fakelogin
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,8 @@ workflows:
       - build:
         filters:
           branches:
-            ignore:
-              - staging
-              - fakelogin
+            ignore: staging
+            ignore: fakelogin
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
       - build:
         filters:
           branches:
-            only: 
+            only:
               - master
               - develop
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,11 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build:
-        branches:
-          ignore:
-            - staging
-            - fakelogin
+          filters:
+            branches:
+              ignore:
+                - staging
+                - fakelogin
   nightly: 
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,11 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build
+        filters: 
+          branches:
+            ignore:
+              - staging
+              - fakelogin
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,10 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build:
-        filters:
-          branches:
-            ignore: 
-              - staging
+        branches:
+          ignore: 
+            - staging
+            - fakelogin
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,8 +178,9 @@ workflows:
       - build:
         filters:
           branches:
-            ignore: staging
-            ignore: fakelogin
+            ignore: 
+              - fakelogin
+              - staging
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ workflows:
         filters:
           branches:
             ignore: 
-              - fakelogin
               - staging
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,11 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build:
-        branches:
-          ignore: 
-            - staging
-            - fakelogin
+        filters:
+          branches:
+            only: 
+              - master
+              - develop
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,12 +176,11 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build:
-        filters:
-          branches:
-            only:
-              - master
-              - develop
-  nightly:
+        branches:
+          ignore:
+            - staging
+            - fakelogin
+  nightly: 
     jobs:
       - prod-test
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,12 +175,11 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - build
-        filters: 
-          branches:
-            ignore:
-              - staging
-              - fakelogin
+      - build 
+        branches:
+          ignore:
+            - staging
+            - fakelogin
   nightly:
     jobs:
       - prod-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - build 
+      - build:
         branches:
           ignore:
             - staging

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -369,8 +369,7 @@ if NON_PROD_INSTANCE_NAME == 'staging':
     BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
         '137.103.146.76',
         '69.243.1.128',
-        '34.196.74.17',
-        '127.0.0.1'
+        '34.196.74.17'
     ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -368,7 +368,10 @@ if NON_PROD_INSTANCE_NAME == 'staging':
     # todo: put these in an environment variable so they aren't exposed through the code
     BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
         '137.103.146.76',
-        '69.243.1.128'
+        '69.243.1.128',
+        '34.196.74.17',
+        '127.0.0.1'
+
     ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -365,8 +365,10 @@ if DEBUG and not HIDE_DEBUG_UI:
 if NON_PROD_INSTANCE_NAME == 'staging':
     UAA_AUTH_URL = "fake:"
     UAA_AUTH_URL = "fake:"
+    # todo: put these in an environment variable so they aren't exposed through the code
     BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
-        '137.103.146.76'
+        '137.103.146.76',
+        '69.243.1.128'
     ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -366,7 +366,7 @@ if NON_PROD_INSTANCE_NAME == 'staging':
     UAA_AUTH_URL = "fake:"
     UAA_AUTH_URL = "fake:"
     BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
-    '137.103.146.76'
+        '137.103.146.76'
     ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -180,6 +180,8 @@ MIDDLEWARE_CLASSES = (
     'calc.middleware.DebugOnlyDebugToolbarMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'admin_reorder.middleware.ModelAdminReorder',
+
+    'baipw.middleware.BasicAuthIPWhitelistMiddleware'
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -359,20 +361,24 @@ if DEBUG and not HIDE_DEBUG_UI:
     DATA_CAPTURE_SCHEDULES += (
         'data_capture.schedules.fake_schedule.FakeSchedulePriceList',
     )
+    
+BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
+    '137.103.146.76'
+]
 
-UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'
+if NON_PROD_INSTANCE_NAME == 'staging':
+    UAA_AUTH_URL = "fake:"
+    UAA_AUTH_URL = "fake:"
+else:
+    UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'
+    UAA_TOKEN_URL = 'https://uaa.fr.cloud.gov/oauth/token'
 
-UAA_TOKEN_URL = 'https://uaa.fr.cloud.gov/oauth/token'
 
-# STAGING ID -@TODO fix
-UAA_CLIENT_ID = '45021bd6-c98b-4580-b4c7-ec0498b1ba63'
-# os.environ.get('UAA_CLIENT_ID', 'calc-dev')
+os.environ.get('UAA_CLIENT_ID', '')
 
 UAA_LOGOUT_URL = 'https://login.fr.cloud.gov/logout.do'
 
-# staging ID -@todo fix
-UAA_CLIENT_SECRET = 'oxYSZ.NA_Shka,9RSpWfrZPxpk3Vjnk.'
-# os.environ.get('UAA_CLIENT_SECRET')
+os.environ.get('UAA_CLIENT_SECRET','')
 
 LOGIN_URL = 'uaa_client:login'
 

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -371,7 +371,6 @@ if NON_PROD_INSTANCE_NAME == 'staging':
         '69.243.1.128',
         '34.196.74.17',
         '127.0.0.1'
-
     ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'

--- a/calc/settings.py
+++ b/calc/settings.py
@@ -361,14 +361,13 @@ if DEBUG and not HIDE_DEBUG_UI:
     DATA_CAPTURE_SCHEDULES += (
         'data_capture.schedules.fake_schedule.FakeSchedulePriceList',
     )
-    
-BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
-    '137.103.146.76'
-]
 
 if NON_PROD_INSTANCE_NAME == 'staging':
     UAA_AUTH_URL = "fake:"
     UAA_AUTH_URL = "fake:"
+    BASIC_AUTH_WHITELISTED_IP_NETWORKS = [
+    '137.103.146.76'
+    ]
 else:
     UAA_AUTH_URL = 'https://login.fr.cloud.gov/oauth/authorize'
     UAA_TOKEN_URL = 'https://uaa.fr.cloud.gov/oauth/token'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     links:
       - db
       - redis
-    command: sh -c "python manage.py collectstatic --noinput ; gunicorn -b :${DOCKER_EXPOSED_PORT} calc.wsgi:application --ciphers TLS_RSA_WITH_AES_256_CBC_SHA256"
+    command: sh -c "python manage.py collectstatic --noinput ; gunicorn -b :${DOCKER_EXPOSED_PORT} calc.wsgi:application --ciphers TLS_RSA_WITH_AES_256_CBC_SHA256 --workers 3"
     ports:
       - "${DOCKER_EXPOSED_PORT}:${DOCKER_EXPOSED_PORT}"
     mem_limit: 1G

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-cors-headers==2.0.2
 django-debug-toolbar==1.6
 django-modeladmin-reorder==0.3.1
 djangorestframework>=3.9.1
+django-basic-auth-ip-whitelist==0.3.4
 gunicorn==19.10.0
 psycopg2==2.7.3.2
 six==1.12.0


### PR DESCRIPTION
Enabling the fake cloud.gov backend and ensuring the gunicorn server locally has enough workers to dispatch fake login requests/response. Adding ip-whitelist package to protect staging from un-authorized ips. To test, I set the BASIC_AUTH_WHITELIST property in settings.py equal to my ip address.